### PR TITLE
allow methods to be awaited

### DIFF
--- a/android/src/main/kotlin/com/apptreesoftware/pusherflutter/PusherFlutterPlugin.kt
+++ b/android/src/main/kotlin/com/apptreesoftware/pusherflutter/PusherFlutterPlugin.kt
@@ -64,9 +64,16 @@ class PusherFlutterPlugin() : MethodCallHandler, ConnectionEventListener {
                     pusherOptions.setCluster(cluster)
                 }
                 pusher = Pusher(apiKey, pusherOptions)
+                result.success(null)
             }
-            "connect" -> pusher?.connect(this, ConnectionState.ALL)
-            "disconnect" -> pusher?.disconnect()
+            "connect" -> {
+                pusher?.connect(this, ConnectionState.ALL)
+                result.success(null)
+            }
+            "disconnect" -> {
+                pusher?.disconnect()
+                result.success(null)
+            }
             "subscribe" -> {
                 val pusher = this.pusher ?: return
                 val event = call.argument<String>("event") ?: throw RuntimeException("Must provide event name")

--- a/ios/Classes/PusherFlutterPlugin.h
+++ b/ios/Classes/PusherFlutterPlugin.h
@@ -13,7 +13,7 @@
 @end
 
 @interface MessageStreamHandler : NSObject<FlutterStreamHandler>
-- (void)send:(NSString *)channel event:(NSString *)event body:(NSDictionary *)body;
+- (void)send:(PTPusherEvent *)event;
 @end
 
 @interface PusherConnectionStateStream : NSObject <FlutterStreamHandler>

--- a/ios/Classes/PusherFlutterPlugin.m
+++ b/ios/Classes/PusherFlutterPlugin.m
@@ -74,7 +74,7 @@
     if ([call.method isEqualToString:@"create"]) {
         NSString *apiKey = call.arguments[@"api_key"];
         NSString *cluster = call.arguments[@"cluster"];
-        if ([cluster isEqual:nil] || [cluster isEqualToString:@""]) {
+        if ([cluster length] == 0) {
             self.pusher = [PTPusher pusherWithKey:apiKey delegate:self encrypted:YES];
         } else {
             self.pusher = [PTPusher pusherWithKey:apiKey delegate:self encrypted:YES cluster:cluster];

--- a/ios/Classes/PusherFlutterPlugin.m
+++ b/ios/Classes/PusherFlutterPlugin.m
@@ -74,7 +74,11 @@
     if ([call.method isEqualToString:@"create"]) {
         NSString *apiKey = call.arguments[@"api_key"];
         NSString *cluster = call.arguments[@"cluster"];
-        self.pusher = [PTPusher pusherWithKey:apiKey delegate:self encrypted:YES cluster:cluster];
+        if ([cluster isEqual:nil] || [cluster isEqualToString:@""]) {
+            self.pusher = [PTPusher pusherWithKey:apiKey delegate:self encrypted:YES];
+        } else {
+            self.pusher = [PTPusher pusherWithKey:apiKey delegate:self encrypted:YES cluster:cluster];
+        }
         result(@(YES));
     } else if ([call.method isEqualToString:@"connect"]) {
         [self.pusher connect];
@@ -89,7 +93,7 @@
         if (!channel) {
             channel = [self.pusher subscribeToChannelNamed:channelName];
         }
-        [self listenToChannel:channel forEvent:event];
+        [channel bindToEventNamed:event target:self action:@selector(forwardEvent:)];
         result(@(YES));
     } else if ([call.method isEqualToString:@"unsubscribe"]) {
         PTPusherChannel *channel = [self.pusher channelNamed:call.arguments];
@@ -102,10 +106,8 @@
     result(FlutterMethodNotImplemented);
 }
 
-- (void)listenToChannel:(PTPusherChannel *)channel forEvent:(NSString *)event {
-    [channel bindToEventNamed:event handleWithBlock:^(PTPusherEvent *e) {
-        [_messageStreamHandler send:channel.name event:event body:e.data];
-    }];
+- (void)forwardEvent:(PTPusherEvent *)event {
+    [_messageStreamHandler send:event];
 }
 
 @end
@@ -119,9 +121,9 @@
     return nil;
 }
 
-- (void)send:(NSString *)channel event:(NSString *)event body:(id)body {
+- (void)send:(PTPusherEvent *)event {
     if (_eventSink) {
-        NSDictionary *dictionary = @{@"channel": channel, @"event": event, @"body": body};
+        NSDictionary *dictionary = @{@"channel": event.channel, @"event": event.name, @"body": event.data};
         _eventSink(dictionary);
     }
 }

--- a/ios/pusher_flutter.podspec
+++ b/ios/pusher_flutter.podspec
@@ -3,7 +3,7 @@
 #
 Pod::Spec.new do |s|
   s.name             = 'pusher_flutter'
-  s.version          = '0.0.1'
+  s.version          = '0.0.8'
   s.summary          = 'A new Flutter project.'
   s.description      = <<-DESC
 A new Flutter project.
@@ -15,8 +15,8 @@ A new Flutter project.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'libPusher'
-  
+  s.dependency 'libPusher', '1.5'
+
   s.ios.deployment_target = '8.0'
 end
 

--- a/lib/pusher_flutter.dart
+++ b/lib/pusher_flutter.dart
@@ -12,68 +12,60 @@ enum PusherConnectionState {
 }
 
 class PusherFlutter {
-  MethodChannel _channel;
-  EventChannel _connectivityEventChannel;
-  EventChannel _messageChannel;
-  EventChannel _errorChannel;
+  final MethodChannel _channel;
+  final EventChannel _connectivityEventChannel;
+  final EventChannel _messageChannel;
+  final EventChannel _errorChannel;
 
   /// Creates a [PusherFlutter] with the specified [apiKey] from pusher.
   ///
   /// The [apiKey] may not be null.
-  PusherFlutter(String apiKey, {String cluster}) {
-    _channel = new MethodChannel('plugins.apptreesoftware.com/pusher');
+  PusherFlutter(String apiKey, {String cluster})
+      : _connectivityEventChannel =
+            new EventChannel('plugins.apptreesoftware.com/pusher_connection'),
+        _messageChannel =
+            new EventChannel('plugins.apptreesoftware.com/pusher_message'),
+        _errorChannel =
+            new EventChannel('plugins.apptreesoftware.com/pusher_error'),
+        _channel = new MethodChannel('plugins.apptreesoftware.com/pusher') {
     var args = {"api_key": apiKey};
     if (cluster != null) {
       args["cluster"] = cluster;
     }
     _channel.invokeMethod('create', args);
-    _connectivityEventChannel =
-        new EventChannel('plugins.apptreesoftware.com/pusher_connection');
-    _messageChannel =
-        new EventChannel('plugins.apptreesoftware.com/pusher_message');
-    _errorChannel =
-        new EventChannel('plugins.apptreesoftware.com/pusher_error');
   }
 
   /// Connect to the pusher service.
-  void connect() {
-    _channel.invokeMethod('connect');
-  }
+  Future<void> connect() => _channel.invokeMethod('connect');
 
   /// Disconnect from the pusher service
-  void disconnect() {
-    _channel.invokeMethod('disconnect');
-  }
+  Future<void> disconnect() => _channel.invokeMethod('disconnect');
 
   /// Subscribe to a channel with the name [channelName] for the event [event]
   ///
   /// Calling this method will cause any messages matching the [event] and [channelName]
   /// provided to be delivered to the [onMessage] method. After calling this you
   /// must listen to the [Stream] returned from [onMessage].
-  void subscribe(String channelName, String event) {
-    _channel
-        .invokeMethod('subscribe', {"channel": channelName, "event": event});
-  }
+  Future<void> subscribe(String channelName, String event) => _channel
+      .invokeMethod('subscribe', {"channel": channelName, "event": event});
 
   /// Subscribe to the channel [channelName] for each [eventName] in [events]
   ///
   /// This method is just for convenience if you need to register multiple events
   /// for the same channel.
-  void subscribeAll(String channelName, List<String> events) {
-    events.forEach((e) => _channel
-        .invokeMethod('subscribe', {"channel": channelName, "event": e}));
+  Future<void> subscribeAll(String channelName, List<String> events) async {
+    final subscriptions = events.map((e) => subscribe(channelName, e));
+    await Future.wait(subscriptions);
   }
 
   /// Unsubscribe from a channel with the name [channelName]
   ///
   /// This will un-subscribe you from all events on that channel.
-  void unsubscribe(String channelName) {
-    _channel.invokeMethod('unsubscribe', channelName);
-  }
+  Future<void> unsubscribe(String channelName) =>
+      _channel.invokeMethod('unsubscribe', channelName);
 
   /// Get the [Stream] of [PusherMessage] for the channels and events you've
   /// signed up for.
-  ///
   Stream<PusherMessage> get onMessage =>
       _messageChannel.receiveBroadcastStream().map(_toPusherMessage);
 
@@ -132,4 +124,6 @@ class PusherError {
   final String message;
 
   PusherError(this.code, this.message);
+
+  toString() => "$code,$message";
 }


### PR DESCRIPTION
* Invoked methods can be awaited by the end implementation
* Channel instance variables can be `final`
* iOS: if cluster is not passed or is blank, a PTPusher's other initialized is used
* Android: parity by calling `result.success` after all methods